### PR TITLE
Add Actions

### DIFF
--- a/packages/actions/__tests__/action.tsx
+++ b/packages/actions/__tests__/action.tsx
@@ -1,0 +1,136 @@
+import React, { Component, useEffect } from 'react'
+import { Observable, Subject, firstValueFrom, take } from 'rxjs'
+import { useObservable, usePromise } from '../src/promise'
+
+import { act, cleanup, render, screen } from '@testing-library/react'
+import { unawaited } from '../src/utility'
+import { useAction } from '../src/action'
+
+describe('useAction', () => {
+  let callCount = 0
+  beforeEach(() => (callCount = 0))
+
+  const ActionComponent: React.FC<{
+    invoker: Subject<boolean>
+    resultGate?: Subject<boolean>
+    resetter?: Subject<boolean>
+  }> = ({ invoker, resultGate, resetter }) => {
+    const [invokeCommand, current, reset] = useAction(
+      async () => {
+        callCount++
+        if (resultGate) {
+          await firstValueFrom(resultGate.pipe(take(1)))
+        }
+
+        return callCount.toString()
+      },
+      [],
+      false
+    )
+
+    // This is a Hack to let us call invokeCommand from the test
+    useEffect(() => {
+      invoker.subscribe(() => unawaited(invokeCommand()))
+    }, [invoker, invokeCommand])
+
+    useEffect(() => {
+      if (!resetter) return
+      resetter.subscribe(() => reset())
+    }, [resetter, reset])
+
+    if (current.isPending()) {
+      return <p>Pending!</p>
+    }
+
+    if (current.isErr()) {
+      return <p>Error!</p>
+    }
+
+    return <p>{current.expect() ?? 'null!'}</p>
+  }
+
+  const expectNullString = async () =>
+    expect(await screen.findByText('null!')).toBeInTheDocument()
+
+  const expectCount = async (n: number) =>
+    expect(await screen.findByText(`${n}`)).toBeInTheDocument()
+
+  const expectPending = async () =>
+    expect(await screen.findByText(`Pending!`)).toBeInTheDocument()
+
+  it('should update on item', async () => {
+    const invoke = new Subject<boolean>()
+
+    render(<ActionComponent invoker={invoke} />)
+
+    // Commands shouldn't invoke immediately, only when we call invokeCommand
+    await expectNullString()
+    expect(callCount).toBe(0)
+
+    // Reach into the Component and fire invokeCommand
+    act(() => invoke.next(true))
+
+    expect(callCount).toBe(1)
+    await expectCount(1)
+  })
+
+  it('should ignore multiple invocations', async () => {
+    const invoke = new Subject<boolean>()
+    const result = new Subject<boolean>()
+
+    render(<ActionComponent invoker={invoke} resultGate={result} />)
+
+    // Commands shouldn't invoke immediately, only when we call invokeCommand
+    expect(await screen.findByText('null!')).toBeInTheDocument()
+    expect(callCount).toBe(0)
+
+    // Kick off our first invocation, this one should Work
+    act(() => invoke.next(true))
+    expect(callCount).toBe(1)
+    await expectPending()
+
+    // Try to invoke while one is already in-flight, it should be ignored (i.e.
+    // the callCount should not change)
+    act(() => invoke.next(true))
+    expect(callCount).toBe(1)
+    await expectPending()
+
+    // Complete the initial invocation, we expect current to be updated
+    act(() => result.next(true))
+    await expectCount(1)
+
+    // Kick off an invocation again, this time we expect it to work because
+    // we have nothing in-flight
+    act(() => invoke.next(true))
+    expect(callCount).toBe(2)
+    await expectPending()
+
+    // Complete the second invocation, see the result show up
+    act(() => result.next(true))
+    await expectCount(2)
+  })
+
+  it('should reset when we ask it to', async () => {
+    const invoke = new Subject<boolean>()
+    const resetSubj = new Subject<boolean>()
+
+    render(<ActionComponent invoker={invoke} resetter={resetSubj} />)
+
+    // Commands shouldn't invoke immediately, only when we call invokeCommand
+    await expectNullString()
+    expect(callCount).toBe(0)
+
+    // Reach into the Component and fire invokeCommand
+    act(() => invoke.next(true))
+    expect(callCount).toBe(1)
+
+    // We now expect the result to be delivered
+    await expectCount(1)
+
+    act(() => resetSubj.next(true))
+
+    // We expect the result to be set back to pending
+    expect(callCount).toBe(1)
+    await expectNullString()
+  })
+})

--- a/packages/actions/__tests__/promise.tsx
+++ b/packages/actions/__tests__/promise.tsx
@@ -2,13 +2,7 @@ import React from 'react'
 import { Observable, Subject, firstValueFrom } from 'rxjs'
 import { useObservable, usePromise } from '../src/promise'
 
-import {
-  act,
-  cleanup,
-  getAllByTestId,
-  render,
-  screen,
-} from '@testing-library/react'
+import { act, cleanup, render, screen } from '@testing-library/react'
 
 function PromiseComponent(props: { p: Promise<number> }) {
   const box = usePromise(() => props.p, [props.p])

--- a/packages/actions/src/action.ts
+++ b/packages/actions/src/action.ts
@@ -1,0 +1,70 @@
+import { useCallback, useMemo, useRef, useState } from 'react'
+import { usePromise } from './promise'
+import { Result } from './result'
+import { promiseFinally, useMounted } from './utility'
+
+type ActionResult<T> = [
+  // InvokeAction => Invokes the action, call this in an event handler
+  () => Promise<T | null>,
+  // Result => The last result from the command invocation
+  Result<T | null>,
+  // Reset => Resets the action to its unset value
+  () => void
+]
+
+export function useAction<T>(
+  block: () => Promise<T>,
+  deps: React.DependencyList,
+  runOnStart = false
+): ActionResult<T> {
+  const mounted = useMounted()
+  const [current, setCurrent] = useState<Result<T | null>>(Result.ok(null))
+
+  const reset = useCallback(() => {
+    if (mounted.current) {
+      setCurrent(Result.ok(null))
+    }
+  }, [mounted])
+
+  const invokeCommand = useAsyncCallbackDedup(async () => {
+    try {
+      if (mounted.current) setCurrent(Result.pending<T>())
+      const ret = await block()
+      if (mounted.current) setCurrent(Result.ok(ret))
+
+      return ret
+    } catch (e) {
+      if (mounted.current) setCurrent(Result.err(e as Error))
+      throw e
+    }
+  }, deps)
+
+  usePromise(async () => {
+    if (runOnStart) {
+      await invokeCommand()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [invokeCommand])
+
+  return useMemo(
+    () => [invokeCommand, current, reset],
+    [invokeCommand, current, reset]
+  )
+}
+
+export function useAsyncCallbackDedup<T>(
+  block: () => Promise<T>,
+  deps: React.DependencyList
+): () => Promise<T | null> {
+  const cur = useRef<Promise<T>>()
+
+  const cb = useCallback(async () => {
+    if (cur.current) return null
+
+    cur.current = block()
+    return await promiseFinally(cur.current, () => (cur.current = undefined))
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps)
+
+  return cb
+}

--- a/packages/actions/src/promise.ts
+++ b/packages/actions/src/promise.ts
@@ -8,7 +8,7 @@ export function useObservable<T>(
   block: () => Observable<T>,
   deps?: React.DependencyList
 ): Result<T> {
-  const [ret, setRet] = useState(Result.Pending<T>())
+  const [ret, setRet] = useState(Result.pending<T>())
   const mounted = useMounted()
 
   useEffect(() => {
@@ -23,13 +23,13 @@ export function useObservable<T>(
       d = block().subscribe({
         next: (x) => {
           set = true
-          if (mounted.current) setRet(Result.Ok(x))
+          if (mounted.current) setRet(Result.ok(x))
         },
         error: (e) => {
           set = true
           done = true
           if (mounted.current) {
-            setRet(Result.Err(e))
+            setRet(Result.err(e))
           }
         },
         complete: () => {
@@ -37,7 +37,7 @@ export function useObservable<T>(
           Promise.resolve().then(() => {
             if (ret.isPending() && !set) {
               setRet(
-                Result.Err(
+                Result.err(
                   new Error('Observable must have at least one element')
                 )
               )
@@ -46,7 +46,7 @@ export function useObservable<T>(
         },
       })
     } catch (e: any) {
-      setRet(Result.Err(e))
+      setRet(Result.err(e))
     }
 
     return () => d.unsubscribe()

--- a/packages/actions/src/result.ts
+++ b/packages/actions/src/result.ts
@@ -1,27 +1,27 @@
 export abstract class Result<T> {
-  abstract isOk(): boolean;
-  abstract isErr(): boolean;
-  abstract isPending(): boolean;
-  abstract ok(): T | undefined;
-  abstract err(): any;
+  abstract isOk(): boolean
+  abstract isErr(): boolean
+  abstract isPending(): boolean
+  abstract ok(): T | undefined
+  abstract err(): any
 
-  static Ok<T>(val: T): Result<T> {
-    return new OkValue<T>(val);
+  static ok<T>(val: T): Result<T> {
+    return new OkValue<T>(val)
   }
 
-  static Err<T>(err: any): Result<T> {
-    return new ErrorValue<T>(err);
+  static err<T>(err: any): Result<T> {
+    return new ErrorValue<T>(err)
   }
 
-  static Pending<T>(): Result<T> {
-    return new PendingValue<T>();
+  static pending<T>(): Result<T> {
+    return new PendingValue<T>()
   }
 
   static fromPromise<T>(val: Promise<T>): Promise<Result<T>> {
     return val.then(
-      (x) => Result.Ok(x),
-      (ex) => Result.Err(ex)
-    );
+      (x) => Result.ok(x),
+      (ex) => Result.err(ex)
+    )
   }
 
   isUndefined() {
@@ -29,40 +29,40 @@ export abstract class Result<T> {
       () => false,
       () => false,
       (x) => x === undefined
-    );
+    )
   }
 
   expect(): T {
     if (!this.isOk()) {
-      throw new Error("Value is not an Ok");
+      throw new Error('Value is not an Ok')
     }
 
-    return this.ok()!;
+    return this.ok()!
   }
 
   expectErr(): any {
     if (!this.isErr()) {
-      throw new Error("Value is not an Error");
+      throw new Error('Value is not an Error')
     }
 
-    return this.err()!;
+    return this.err()!
   }
 
   contains(val: T): boolean {
-    if (!this.isOk()) return false;
-    return this.expect() === val;
+    if (!this.isOk()) return false
+    return this.expect() === val
   }
 
   map<N>(fn: (val: T) => N): Result<N> {
     if (this.isErr()) {
-      return Result.Err<N>(this.expectErr());
+      return Result.err<N>(this.expectErr())
     }
 
     if (this.isPending()) {
-      return Result.Pending();
+      return Result.pending()
     }
 
-    return Result.Ok(fn(this.expect()));
+    return Result.ok(fn(this.expect()))
   }
 
   mapOrElse<N>(
@@ -71,118 +71,118 @@ export abstract class Result<T> {
     fn: (val: T) => N
   ): N {
     if (this.isPending()) {
-      return orPending();
+      return orPending()
     }
 
     if (this.isErr()) {
-      return orElse(this.expectErr());
+      return orElse(this.expectErr())
     }
 
-    return fn(this.expect());
+    return fn(this.expect())
   }
 
   mapErr(fn: (val: any) => any): Result<T> {
-    if (this.isOk()) return Result.Ok<T>(this.expect());
-    if (this.isPending()) return Result.Pending<T>();
+    if (this.isOk()) return Result.ok<T>(this.expect())
+    if (this.isPending()) return Result.pending<T>()
 
-    return Result.Err(fn(this.expectErr()));
+    return Result.err(fn(this.expectErr()))
   }
 
   and<N>(res: Result<N>): Result<N> {
-    if (this.isPending()) return Result.Pending<N>();
-    return this.isOk() ? res : Result.Err<N>(this.expectErr());
+    if (this.isPending()) return Result.pending<N>()
+    return this.isOk() ? res : Result.err<N>(this.expectErr())
   }
 
   andThen<N>(res: (val: T) => Result<N>): Result<N> {
-    if (this.isPending()) return Result.Pending<N>();
-    return this.isOk() ? res(this.expect()) : Result.Err(this.expectErr());
+    if (this.isPending()) return Result.pending<N>()
+    return this.isOk() ? res(this.expect()) : Result.err(this.expectErr())
   }
 
   or(res: Result<T>): Result<T> {
-    return this.isErr() ? res : this;
+    return this.isErr() ? res : this
   }
 }
 
 class OkValue<T> extends Result<T> {
-  value: T;
+  value: T
 
   constructor(val: T) {
-    super();
-    this.value = val;
+    super()
+    this.value = val
   }
 
   isOk(): boolean {
-    return true;
+    return true
   }
 
   isErr(): boolean {
-    return false;
+    return false
   }
 
   isPending(): boolean {
-    return false;
+    return false
   }
 
   ok(): T | undefined {
-    return this.value;
+    return this.value
   }
 
   err(): any | undefined {
-    return undefined;
+    return undefined
   }
 }
 
 class ErrorValue<T> extends Result<T> {
-  value: any;
+  value: any
 
   constructor(val: any) {
-    super();
-    this.value = val;
+    super()
+    this.value = val
   }
 
   isOk(): boolean {
-    return false;
+    return false
   }
 
   isErr(): boolean {
-    return true;
+    return true
   }
 
   isPending(): boolean {
-    return false;
+    return false
   }
 
   ok(): T | undefined {
-    return undefined;
+    return undefined
   }
 
   err(): any | undefined {
-    return this.value;
+    return this.value
   }
 }
 
 class PendingValue<T> extends Result<T> {
   constructor() {
-    super();
+    super()
   }
 
   isOk(): boolean {
-    return false;
+    return false
   }
 
   isErr(): boolean {
-    return false;
+    return false
   }
 
   isPending(): boolean {
-    return true;
+    return true
   }
 
   ok(): T | undefined {
-    return undefined;
+    return undefined
   }
 
   err(): any | undefined {
-    return undefined;
+    return undefined
   }
 }

--- a/packages/actions/src/utility.ts
+++ b/packages/actions/src/utility.ts
@@ -34,3 +34,16 @@ export function cx(...args: (string | null | undefined | false)[]) {
     }, [])
     .join(' ')
 }
+
+export function promiseFinally<T>(p: Promise<T>, block: () => unknown) {
+  return p.then(
+    (x) => {
+      block()
+      return Promise.resolve(x)
+    },
+    (e) => {
+      block()
+      return Promise.reject(e)
+    }
+  )
+}

--- a/packages/actions/src/utility.ts
+++ b/packages/actions/src/utility.ts
@@ -21,6 +21,10 @@ export function useExplicitRender() {
   return { dep: n, rerender }
 }
 
+export function unawaited<T>(p: Promise<T>) {
+  p.then((_) => {})
+}
+
 export function cx(...args: (string | null | undefined | false)[]) {
   return args
     .reduce((acc: string[], arg) => {


### PR DESCRIPTION
This PR adds Actions, which are a tool you use when you want to kick off an async action as a result of an event. We should also eventually add a `useAction` for Observables too